### PR TITLE
Add nebulo to the best use section of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ IP Extension | Malicious IP protection. | MID - HIGH END | 56,228 | 792K | [/e/i
 You can use any `practical` way you want to use Energized Protection on your devices, if you know what you are doing. But if you are clueless, there are few suggestions.
 
 - __rooted android:__ `Energized Protection` Magisk Module makes your experience better on Magisk-ly Rooted Android devices. Grab it from `Magisk Manager > Download`. If you aren't that familiar with that stuff, then you can use [`AdAway (Latest)`](https://adaway.org/) with GIT RAW Sources now. 
-- __non-rooted android:__ If you are not using any root solution, then you can use [`DNS66`](https://github.com/julian-klode/dns66), [`BLOKADA`](https://blokada.org/), [`Personal DNS Filter`](https://www.zenz-solutions.de/personaldnsfilter/) or [`Nebulo`](https://git.frostnerd.com/PublicAndroidApps/smokescreen) with any of the Energized Source.
+- __non-rooted android:__ If you are not using any root solution, then you can use [`DNS66`](https://github.com/julian-klode/dns66), [`BLOKADA`](https://blokada.org/), [`Personal DNS Filter`](https://www.zenz-solutions.de/personaldnsfilter/) or [`Nebulo`](https://nebulo.app/source) with any of the Energized Source.
 - __ios:__ Use any `Adblocking Client` app with Energized Source.
 - __windows:__ On Windows, you can use [`HostsMan`](http://www.abelhadigital.com/hostsman/) to get the best Windows Hosts Usage Experience.
 - __linux:__ `Energized Protection` Linux Script is there for you! Check [here](https://github.com/EnergizedProtection/Energized_Linux) for more info. 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ IP Extension | Malicious IP protection. | MID - HIGH END | 56,228 | 792K | [/e/i
 You can use any `practical` way you want to use Energized Protection on your devices, if you know what you are doing. But if you are clueless, there are few suggestions.
 
 - __rooted android:__ `Energized Protection` Magisk Module makes your experience better on Magisk-ly Rooted Android devices. Grab it from `Magisk Manager > Download`. If you aren't that familiar with that stuff, then you can use [`AdAway (Latest)`](https://adaway.org/) with GIT RAW Sources now. 
-- __non-rooted android:__ If you are not using any root solution, then you can use [`DNS66`](https://github.com/julian-klode/dns66), [`BLOKADA`](https://blokada.org/) or [`Personal DNS Filter`](https://www.zenz-solutions.de/personaldnsfilter/) with any of the Energized Source.
+- __non-rooted android:__ If you are not using any root solution, then you can use [`DNS66`](https://github.com/julian-klode/dns66), [`BLOKADA`](https://blokada.org/), [`Personal DNS Filter`](https://www.zenz-solutions.de/personaldnsfilter/) or [`Nebulo`](https://git.frostnerd.com/PublicAndroidApps/smokescreen) with any of the Energized Source.
 - __ios:__ Use any `Adblocking Client` app with Energized Source.
 - __windows:__ On Windows, you can use [`HostsMan`](http://www.abelhadigital.com/hostsman/) to get the best Windows Hosts Usage Experience.
 - __linux:__ `Energized Protection` Linux Script is there for you! Check [here](https://github.com/EnergizedProtection/Energized_Linux) for more info. 

--- a/assets/readme/readme.template
+++ b/assets/readme/readme.template
@@ -130,10 +130,10 @@ IP Extension | Malicious IP protection. | MID - HIGH END | _ipsext_ | _ipsexts_ 
 
 You can use any `practical` way you want to use Energized Protection on your devices, if you know what you are doing. But if you are clueless, there are few suggestions.
 
-- __rooted android:__ `Energized Protection` Magisk Module makes your experience better on Magisk-ly Rooted Android devices. Grab it from `Magisk Manager > Download`. If you aren't that familiar with that stuff, then you can use `AdAway (Latest)` with GIT RAW Sources now. 
-- __non-rooted android:__ If you are not using any root solution, then you can use `DNS66`, `BLOKADA` or `Perosnal DNS Filter` with any of the Energized Source.
+- __rooted android:__ `Energized Protection` Magisk Module makes your experience better on Magisk-ly Rooted Android devices. Grab it from `Magisk Manager > Download`. If you aren't that familiar with that stuff, then you can use [`AdAway (Latest)`](https://adaway.org/) with GIT RAW Sources now. 
+- __non-rooted android:__ If you are not using any root solution, then you can use [`DNS66`](https://github.com/julian-klode/dns66), [`BLOKADA`](https://blokada.org/), [`Personal DNS Filter`](https://www.zenz-solutions.de/personaldnsfilter/) or [`Nebulo`](https://nebulo.app/source) with any of the Energized Source.
 - __ios:__ Use any `Adblocking Client` app with Energized Source.
-- __windows:__ On Windows, you can use `HostsMan` to get the best Windows Hosts Usage Experience.
+- __windows:__ On Windows, you can use [`HostsMan`](http://www.abelhadigital.com/hostsman/) to get the best Windows Hosts Usage Experience.
 - __linux:__ `Energized Protection` Linux Script is there for you! Check [here](https://github.com/EnergizedProtection/Energized_Linux) for more info. 
 
 For further assistance, knock us on our [Telegram Group](http://go.energized.pro/telegram) or visit our [instructions](https://energized.pro/instructions) page.


### PR DESCRIPTION
I'm the developer of Nebulo, a DoH and DoT client for Android 5.0 and up.

Some Energized lists are included by default as host sources on non-playstore builds of the app and it would be awesome if Nebulo could be listed in the best use section of the readme.

![image](https://user-images.githubusercontent.com/26578153/66420900-20f35780-ea07-11e9-9f57-26ce581e09e9.png)
