### PR TITLE
Changed the neoHosts version

### DIFF
--- a/assets/sources/sources.json
+++ b/assets/sources/sources.json
@@ -121,7 +121,7 @@
   {"name": "mitchellkrogza-badd-boyz-hosts",     "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts"},
   {"name": "mobile-ad-trackers",                 "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://raw.githubusercontent.com/jawz101/MobileAdTrackers/master/hosts"},
   {"name": "molinero-hblock",                    "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://hblock.molinero.dev/hosts"},
-  {"name": "neohost",                            "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://hosts.nfz.moe/full/hosts"},
+  {"name": "neohost",                            "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://hosts.nfz.moe/basic/hosts"},
   {"name": "notracking",                         "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://raw.githubusercontent.com/notracking/hosts-blocklists/master/hostnames.txt"},
   {"name": "openphish",                          "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://v.firebog.net/hosts/Openphish.txt"},
   {"name": "pgl.yoyo.org",                       "enabled": true,    "filter": "active",    "format": "plain",    "url": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=nohtml&mimetype=plaintext"},


### PR DESCRIPTION
Apparently [*neoHosts Full* contains anti-Falun Gong entries](https://github.com/neoFelhz/neohosts/blob/data/_data/extra/fuck_falun_gong.txt), which seems like a pretty weird thing to do in the eyes of most people outside of PR-China. So I figured this was a good time to change the neoHosts source to a list version of theirs that doesn't contain such entries (that I know of).