### PR TITLE
Add RethinkDNS + Firewall to Readme

### DIFF
--- a/assets/readme/readme.template
+++ b/assets/readme/readme.template
@@ -126,7 +126,7 @@ IP Extension | Malicious IP protection. | MID - HIGH END | _ipsext_ | _ipsexts_ 
 You can use any `practical` way you want to use Energized Protection on your devices, if you know what you are doing. But if you are clueless, there are few suggestions.
 
 - __rooted android:__ `Energized Protection` Magisk Module makes your experience better on Magisk-ly Rooted Android devices. Grab it from `Magisk Manager > Download`. If you aren't that familiar with that stuff, then you can use [`AdAway (Latest)`](https://adaway.org/) with GIT RAW Sources now. 
-- __non-rooted android:__ If you are not using any root solution, then you can use [`DNS66`](https://github.com/julian-klode/dns66), [`BLOKADA`](https://blokada.org/), [`Personal DNS Filter`](https://www.zenz-solutions.de/personaldnsfilter/) or [`Nebulo`](https://nebulo.app/source) with any of the Energized Source.
+- __non-rooted android:__ If you are not using any root solution, then you can use [`DNS66`](https://github.com/julian-klode/dns66), [`Blokada`](https://blokada.org/), [`Personal DNS Filter`](https://www.zenz-solutions.de/personaldnsfilter/), [`Nebulo`](https://nebulo.app/source), or [`RethinkDNS + Firewall`](https://github.com/celzero/rethink-app) with any of the Energized Source.
 - __ios:__ Use any `Adblocking Client` app with Energized Protection Source.
 - __windows:__ On Windows, you can use [`HostsMan`](http://www.abelhadigital.com/hostsman/) to get the best Windows Hosts Usage Experience. Make sure to disable DNS Client Service.
 - __linux:__ `Energized Protection` Linux Script is there for you! Check [here](https://github.com/EnergizedProtection/Energized_Linux) for more info. Or, simply use hosts!


### PR DESCRIPTION
RethinkDNS supports energized blocklists both for on-device
and on-server content-blocking, see: [rethinkdns/configure#1:gAEPAADg](https://rethinkdns.com/configure#1:gAEPAADg).