### PR TITLE
Update clefspeare13 source

### DIFF
--- a/assets/sources/sources.json
+++ b/assets/sources/sources.json
@@ -240,10 +240,10 @@
 	"homepage": "https://github.com/stamparm/blackbook/"
   },
   {
-    "source": "pornhosts",   "maintainer": "Clefspeare13",    "name": "clefspeare-pornhosts",
+    "source": "pornhosts",   "maintainer": "spirillen",    "name": "mypdns-pornhosts",
 	"enabled": true,    "update": "latest",    "filter": "active",    "format": "plain",
-	"url": "https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/download_here/0.0.0.0/hosts",
-	"homepage": "https://github.com/Clefspeare13/pornhosts"
+	"url": "https://mypdns.org/clefspeare13/pornhosts/-/raw/master/download_here/0.0.0.0/hosts",
+	"homepage": "https://mypdns.org/clefspeare13/pornhosts"
   },
   {
     "source": "cybercrime",   "maintainer": "-",    "name": "cybercrime",

--- a/porn/build.sh
+++ b/porn/build.sh
@@ -111,7 +111,7 @@ rm -f $temp
 { cat $oFileDir/domains.txt; \
 cat $fileDir/ador-energized-porn.txt; \
 cat $fileDir/airelle-sex.txt; \
-cat $fileDir/clefspeare-pornhosts.txt; \
+cat $fileDir/mypdns-pornhosts.txt; \
 cat $fileDir/easylist-adult-adservers.txt; \
 cat $fileDir/easylist-adult-specific.txt; \
 cat $fileDir/easylist-adult-thirdparty.txt; \


### PR DESCRIPTION
As @github have decided to disable the original clefspeare13 repo, I (@spirillen as only maintainer) have moved into a privacy safe location + merging it with my own matrix project.

These source links have been updated and the title too.

The sources will be merged with https://mypdns.org/my-privacy-dns/hosts once https://github.com/funilrys/PyFunceble/issues/303 is solved so I can continue with my test script.

If you want's we can add https://mypdns.org/my-privacy-dns/hosts/-/blob/master/download/porn.txt as well to your sources, but this one is NOT checked for dead records, this one is only providing "active" domain according to the issue board.

Best regards

https://mypdns.org/

@spirillen